### PR TITLE
Solc package (solc-select)

### DIFF
--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -11,7 +11,10 @@ jobs:
 
       # Install solc-select
       - name: Install solc-select
-        run: pip3 install solc-select
+        run: |
+          python3 -m venv solgoenv
+          source solgoenv/bin/activate
+          pip3 install solc-select
 
       # Install and set a specific version of solc
       - name: Setup solc

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -8,6 +8,17 @@ jobs:
     steps:
       - name: Checkout Source
         uses: actions/checkout@v3
+
+      # Install solc-select
+      - name: Install solc-select
+        run: pip3 install solc-select
+
+      # Install and set a specific version of solc
+      - name: Setup solc
+        run: |
+          solc-select install 0.8.19
+          solc-select use 0.8.19
+
       - name: Run Gosec Security Scanner
         uses: securego/gosec@master
         with:

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -19,6 +19,7 @@ jobs:
       # Install and set a specific version of solc
       - name: Setup solc
         run: |
+          source solgoenv/bin/activate
           solc-select install 0.8.19
           solc-select use 0.8.19
 

--- a/.github/workflows/goveralls.yml
+++ b/.github/workflows/goveralls.yml
@@ -30,7 +30,9 @@ jobs:
           solc-select install 0.8.19
           solc-select use 0.8.19
 
-      - run: go test -v -coverprofile=profile.cov ./...
+      - run: |
+          source solgoenv/bin/activate
+          go test -v -coverprofile=profile.cov ./...
 
       - name: Send coverage
         uses: shogo82148/actions-goveralls@v1.7.0

--- a/.github/workflows/goveralls.yml
+++ b/.github/workflows/goveralls.yml
@@ -18,7 +18,10 @@ jobs:
 
       # Install solc-select
       - name: Install solc-select
-        run: pip3 install solc-select
+        run: |
+          python3 -m venv solgoenv
+          source solgoenv/bin/activate
+          pip3 install solc-select
 
       # Install and set a specific version of solc
       - name: Setup solc

--- a/.github/workflows/goveralls.yml
+++ b/.github/workflows/goveralls.yml
@@ -26,6 +26,7 @@ jobs:
       # Install and set a specific version of solc
       - name: Setup solc
         run: |
+          source solgoenv/bin/activate
           solc-select install 0.8.19
           solc-select use 0.8.19
 

--- a/.github/workflows/goveralls.yml
+++ b/.github/workflows/goveralls.yml
@@ -16,10 +16,16 @@ jobs:
       - uses: actions/checkout@v3
       - run: make submodules
 
-      - uses: actions/setup-go@v3
-        with:
-          go-version: ${{ matrix.go }}
-      - uses: actions/checkout@v3
+      # Install solc-select
+      - name: Install solc-select
+        run: pip3 install solc-select
+
+      # Install and set a specific version of solc
+      - name: Setup solc
+        run: |
+          solc-select install 0.8.19
+          solc-select use 0.8.19
+
       - run: go test -v -coverprofile=profile.cov ./...
 
       - name: Send coverage

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+solgoenv/*
 
 # Go workspace file
 go.work

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,12 @@ language: go
 go:
   - 1.19.x
 
+before_install:
+  # Install solc-select
+  - pip3 install solc-select
+  # Install a specific version of solc and set it as the current version
+  - solc-select install 0.8.19
+  - solc-select use 0.8.19
+
 script:
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,11 @@ go:
 
 before_install:
   # Install solc-select
+  - python3 -m venv solgoenv
+  - source solgoenv/bin/activate
   - pip3 install solc-select
   # Install a specific version of solc and set it as the current version
   - solc-select install 0.8.19
   - solc-select use 0.8.19
-
 script:
   - make test

--- a/solc/command.go
+++ b/solc/command.go
@@ -1,0 +1,10 @@
+package solc
+
+// Commander interface defines the methods for executing solc-select commands.
+type Commander interface {
+	Current() string
+	Install(version string) (bool, []string, error)
+	Use(version string) (bool, []string, []string, error)
+	Versions() ([]Version, error)
+	Upgrade() (bool, error)
+}

--- a/solc/command_mock.go
+++ b/solc/command_mock.go
@@ -1,0 +1,51 @@
+// Package solc provides functionality related to the Solidity compiler (solc).
+package solc
+
+import "errors"
+
+// MockCommand provides a mock implementation of the Commander interface.
+// It simulates the behavior of solc-select commands for testing purposes.
+type MockCommand struct {
+	// current represents the currently selected version of solc in the mock environment.
+	current string
+}
+
+// Current returns the current version of solc in use in the mock environment.
+func (mc *MockCommand) Current() string {
+	return mc.current
+}
+
+// Install simulates the installation of a specific version of solc.
+// If the version is "0.8.19", it simulates a successful installation.
+// Otherwise, it simulates an installation error.
+func (mc *MockCommand) Install(version string) (bool, []string, error) {
+	if version == "0.8.19" {
+		return true, []string{"Installing solc '0.8.19'...", "Version '0.8.19' installed."}, nil
+	}
+	return false, []string{"Error installing version."}, errors.New("installation error")
+}
+
+// Use simulates the process of switching to a specific version of solc.
+// If the version is "0.8.19", it simulates a successful switch.
+// Otherwise, it simulates an error in switching.
+func (mc *MockCommand) Use(version string) (bool, []string, []string, error) {
+	if version == "0.8.19" {
+		return true, []string{}, []string{"Switched global version to 0.8.19"}, nil
+	}
+	return false, []string{}, []string{"Error switching version."}, errors.New("switch error")
+}
+
+// Versions simulates the retrieval of available solc versions.
+// It returns a predefined list of versions for testing purposes.
+func (mc *MockCommand) Versions() ([]Version, error) {
+	return []Version{
+		{Release: "0.8.19", Current: true},
+		{Release: "0.8.18", Current: false},
+	}, nil
+}
+
+// Upgrade simulates the process of upgrading to the latest version of solc.
+// In this mock implementation, it always simulates a successful upgrade.
+func (mc *MockCommand) Upgrade() (bool, error) {
+	return true, nil
+}

--- a/solc/command_real.go
+++ b/solc/command_real.go
@@ -1,0 +1,145 @@
+package solc
+
+import (
+	"bytes"
+	"errors"
+	"os/exec"
+	"strings"
+)
+
+// RealCommand implements the Commander interface using real solc-select commands.
+type RealCommand struct {
+	current string
+}
+
+// Current returns the current version of solc in use.
+func (rc *RealCommand) Current() string {
+	return rc.current
+}
+
+// Install a specific version of solc.
+// Returns a boolean indicating if the version was installed, a slice of output lines from solc-select, and an error if any occurred.
+func (rc *RealCommand) Install(version string) (bool, []string, error) {
+	cmd := exec.Command("solc-select", "install", version)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err != nil {
+		return false, nil, err
+	}
+
+	// Split the output into lines
+	outputLines := strings.Split(out.String(), "\n")
+
+	// Check if the version was successfully installed
+	isInstalled := false
+	for _, line := range outputLines {
+		if strings.Contains(line, "Version '"+version+"' installed.") {
+			isInstalled = true
+			break
+		}
+	}
+
+	return isInstalled, outputLines, nil
+}
+
+// Use a specific version of solc. If the version does not exist, install it.
+// Returns a boolean indicating success, the outputs from the install and use commands, and an error if any occurred.
+func (rc *RealCommand) Use(version string) (bool, []string, []string, error) {
+	// If the desired version is already the current version, do nothing and return
+	if rc.Current() == version {
+		return true, nil, nil, nil
+	}
+
+	// Check if the version exists
+	versions, err := rc.Versions()
+	if err != nil {
+		return false, nil, nil, err
+	}
+
+	versionExists := false
+	for _, v := range versions {
+		if v.Release == version {
+			versionExists = true
+			break
+		}
+	}
+
+	// If the version is not installed, install it and capture the output
+	var installOutput []string
+	if !versionExists {
+		success, output, err := rc.Install(version)
+		if err != nil || !success {
+			return false, output, nil, err
+		}
+		installOutput = output
+	}
+
+	// Switch to the desired version and capture the output
+	cmd := exec.Command("solc-select", "use", version)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err = cmd.Run()
+	if err != nil {
+		return false, installOutput, nil, err
+	}
+	useOutput := strings.Split(out.String(), "\n")
+
+	// Check if the switch was successful
+	success := strings.Contains(out.String(), "Switched global version to")
+
+	return success, installOutput, useOutput, nil
+}
+
+// Versions lists all available versions of solc using solc-select.
+func (rc *RealCommand) Versions() ([]Version, error) {
+	cmd := exec.Command("solc-select", "versions")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse the output to get the list of versions
+	versionsOutput := out.String()
+	versions := strings.Split(versionsOutput, "\n")
+
+	var versionList []Version
+	for _, version := range versions {
+		if version != "" {
+			isCurrent := strings.Contains(version, "current")
+			release := strings.Fields(version)[0]
+			versionList = append(versionList, Version{
+				Release: release,
+				Current: isCurrent,
+			})
+		}
+	}
+
+	if len(versionList) == 0 {
+		return nil, errors.New("no solc versions found")
+	}
+
+	return versionList, nil
+}
+
+// Upgrade to the latest version of solc.
+// Returns a bool indicating if solc-select is up to date, and an error if any occurred.
+func (rc *RealCommand) Upgrade() (bool, error) {
+	cmd := exec.Command("solc-select", "upgrade")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err != nil {
+		return false, err
+	}
+
+	// Check the output to see if solc-select is already up to date
+	response := out.String()
+	if strings.Contains(response, "already up to date") {
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/solc/doc.go
+++ b/solc/doc.go
@@ -1,0 +1,3 @@
+// The solc package provides a Go interface to manage Solidity compiler versions using solc-select,
+// allowing for the installation, switching, and querying of available compiler versions.
+package solc

--- a/solc/select.go
+++ b/solc/select.go
@@ -1,5 +1,10 @@
 package solc
 
+import (
+	"errors"
+	"os"
+)
+
 type Select struct {
 	current   string
 	commander Commander
@@ -15,8 +20,16 @@ func (s *Select) Current() string {
 // If solc-select is not installed, it returns an error.
 // If solc-select is installed, the function fetches the list of available solc versions.
 // It then identifies the currently active solc version and sets it in the returned Select struct.
+// It checks if a Python virtual environment is set and initializes the current solc version.
 // If any step fails, an error is returned.
 func NewSelect() (*Select, error) {
+	if os.Getenv("VIRTUAL_ENV") == "" {
+		return nil, errors.New(
+			"Python virtual environment is not set. Security risk!\n" +
+				"Please run 'python3 -m venv solgoenv' and 'source solgoenv/bin/activate' before running this command.",
+		)
+	}
+
 	toReturn := &Select{
 		commander: &RealCommand{},
 	}

--- a/solc/select.go
+++ b/solc/select.go
@@ -1,0 +1,60 @@
+package solc
+
+type Select struct {
+	current   string
+	commander Commander
+}
+
+// Get the current version of solc in use.
+func (s *Select) Current() string {
+	return s.current
+}
+
+// NewSelect initializes and returns a new instance of the Select struct.
+// The function first checks if solc-select is installed on the system.
+// If solc-select is not installed, it returns an error.
+// If solc-select is installed, the function fetches the list of available solc versions.
+// It then identifies the currently active solc version and sets it in the returned Select struct.
+// If any step fails, an error is returned.
+func NewSelect() (*Select, error) {
+	toReturn := &Select{
+		commander: &RealCommand{},
+	}
+
+	versions, err := toReturn.Versions()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, version := range versions {
+		if version.Current {
+			toReturn.current = version.Release
+			break
+		}
+	}
+
+	return toReturn, nil
+}
+
+// Install a specific version of solc.
+// Returns a boolean indicating if the version was installed, a slice of output lines from solc-select, and an error if any occurred.
+func (s *Select) Install(version string) (bool, []string, error) {
+	return s.commander.Install(version)
+}
+
+// Use a specific version of solc. If the version does not exist, install it.
+// Returns a boolean indicating success, the outputs from the install and use commands, and an error if any occurred.
+func (s *Select) Use(version string) (bool, []string, []string, error) {
+	return s.commander.Use(version)
+}
+
+// Versions lists all available versions of solc using solc-select.
+func (s *Select) Versions() ([]Version, error) {
+	return s.commander.Versions()
+}
+
+// Upgrade to the latest version of solc.
+// Returns a bool indicating if solc-select is up to date, and an error if any occurred.
+func (s *Select) Upgrade() (bool, error) {
+	return s.commander.Upgrade()
+}

--- a/solc/select_mock_test.go
+++ b/solc/select_mock_test.go
@@ -1,0 +1,136 @@
+package solc
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMockUse(t *testing.T) {
+	tests := []struct {
+		name           string
+		version        string
+		expectedResult bool
+		expectedError  error
+	}{
+		{
+			name:           "Successful switch",
+			version:        "0.8.19",
+			expectedResult: true,
+			expectedError:  nil,
+		},
+		{
+			name:           "Unsuccessful switch",
+			version:        "0.8.20",
+			expectedResult: false,
+			expectedError:  errors.New("switch error"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Select{
+				commander: &MockCommand{},
+			}
+
+			result, _, _, err := s.Use(tt.version)
+			assert.Equal(t, tt.expectedResult, result)
+			assert.Equal(t, tt.expectedError, err)
+		})
+	}
+}
+
+func TestMockInstall(t *testing.T) {
+	tests := []struct {
+		name           string
+		version        string
+		expectedResult bool
+		expectedError  error
+	}{
+		{
+			name:           "Successful install",
+			version:        "0.8.19",
+			expectedResult: true,
+			expectedError:  nil,
+		},
+		{
+			name:           "Unsuccessful install",
+			version:        "0.8.20",
+			expectedResult: false,
+			expectedError:  errors.New("installation error"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Select{
+				commander: &MockCommand{},
+			}
+
+			result, _, err := s.Install(tt.version)
+			assert.Equal(t, tt.expectedResult, result)
+			assert.Equal(t, tt.expectedError, err)
+		})
+	}
+}
+
+func TestMockVersions(t *testing.T) {
+	tests := []struct {
+		name             string
+		expectedVersions []Version
+		expectedError    error
+	}{
+		{
+			name: "Successful retrieval of versions",
+			expectedVersions: []Version{
+				{Release: "0.8.19", Current: true},
+				{Release: "0.8.18", Current: false},
+				// ... add other versions as needed ...
+			},
+			expectedError: nil,
+		},
+		// Note: The MockCommand always returns the versions 0.8.19 (current) and 0.8.18.
+		// If there are scenarios where the retrieval can fail or return different versions, you should add them here.
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Select{
+				commander: &MockCommand{},
+			}
+
+			versions, err := s.Versions()
+			assert.Equal(t, tt.expectedVersions, versions)
+			assert.Equal(t, tt.expectedError, err)
+		})
+	}
+}
+
+func TestMockUpgrade(t *testing.T) {
+	tests := []struct {
+		name           string
+		expectedResult bool
+		expectedError  error
+	}{
+		{
+			name:           "Successful upgrade",
+			expectedResult: true,
+			expectedError:  nil,
+		},
+		// Note: The MockCommand always returns a successful upgrade.
+		// If there are scenarios where the upgrade can fail, you should add them here.
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Select{
+				commander: &MockCommand{},
+			}
+
+			result, err := s.Upgrade()
+			assert.Equal(t, tt.expectedResult, result)
+			assert.Equal(t, tt.expectedError, err)
+		})
+	}
+}

--- a/solc/select_mock_test.go
+++ b/solc/select_mock_test.go
@@ -97,12 +97,17 @@ func TestMockVersions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &Select{
-				commander: &MockCommand{},
+				current: "0.8.19",
+				commander: &MockCommand{
+					current: "0.8.19",
+				},
 			}
 
 			versions, err := s.Versions()
 			assert.Equal(t, tt.expectedVersions, versions)
 			assert.Equal(t, tt.expectedError, err)
+			assert.NotEmpty(t, s.Current())
+			assert.NotEmpty(t, s.commander.Current())
 		})
 	}
 }

--- a/solc/select_mock_test.go
+++ b/solc/select_mock_test.go
@@ -123,8 +123,6 @@ func TestMockUpgrade(t *testing.T) {
 			expectedResult: true,
 			expectedError:  nil,
 		},
-		// Note: The MockCommand always returns a successful upgrade.
-		// If there are scenarios where the upgrade can fail, you should add them here.
 	}
 
 	for _, tt := range tests {

--- a/solc/select_test.go
+++ b/solc/select_test.go
@@ -90,6 +90,7 @@ func TestVersions(t *testing.T) {
 			versions, err := s.Versions()
 			assert.GreaterOrEqual(t, len(versions), 1)
 			assert.Equal(t, tt.expectedError, err)
+			assert.NotEmpty(t, s.Current())
 		})
 	}
 }
@@ -123,7 +124,6 @@ func TestUpgrade(t *testing.T) {
 }
 
 func TestNewSelect(t *testing.T) {
-	t.Skip("Skipping test that requires solc-select to be installed")
 	tests := []struct {
 		name             string
 		expectedError    error

--- a/solc/select_test.go
+++ b/solc/select_test.go
@@ -1,6 +1,7 @@
 package solc
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,6 +24,10 @@ func TestUse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if os.Getenv("TEST_SOLGO_SOLC_SELECT_DISABLED") == "true" {
+				t.Skip("Skipping test that requires solc-select")
+			}
+
 			s, err := NewSelect()
 			assert.NoError(t, err, "NewSelect() should not return an error")
 
@@ -50,6 +55,10 @@ func TestInstall(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if os.Getenv("TEST_SOLGO_SOLC_SELECT_DISABLED") == "true" {
+				t.Skip("Skipping test that requires solc-select")
+			}
+
 			s, err := NewSelect()
 			assert.NoError(t, err, "NewSelect() should not return an error")
 			result, _, err := s.Install(tt.version)
@@ -72,6 +81,10 @@ func TestVersions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if os.Getenv("TEST_SOLGO_SOLC_SELECT_DISABLED") == "true" {
+				t.Skip("Skipping test that requires solc-select")
+			}
+
 			s, err := NewSelect()
 			assert.NoError(t, err, "NewSelect() should not return an error")
 			versions, err := s.Versions()
@@ -96,6 +109,10 @@ func TestUpgrade(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if os.Getenv("TEST_SOLGO_SOLC_SELECT_DISABLED") == "true" {
+				t.Skip("Skipping test that requires solc-select")
+			}
+
 			s, err := NewSelect()
 			assert.NoError(t, err, "NewSelect() should not return an error")
 			result, err := s.Upgrade()
@@ -121,6 +138,10 @@ func TestNewSelect(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if os.Getenv("TEST_SOLGO_SOLC_SELECT_DISABLED") == "true" {
+				t.Skip("Skipping test that requires solc-select")
+			}
+
 			s, err := NewSelect()
 			assert.NoError(t, err, "NewSelect() should not return an error")
 

--- a/solc/select_test.go
+++ b/solc/select_test.go
@@ -1,0 +1,133 @@
+package solc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUse(t *testing.T) {
+	tests := []struct {
+		name           string
+		version        string
+		expectedResult bool
+		expectedError  error
+	}{
+		{
+			name:           "Successful switch",
+			version:        "0.8.20",
+			expectedResult: true,
+			expectedError:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, err := NewSelect()
+			assert.NoError(t, err, "NewSelect() should not return an error")
+
+			result, _, _, err := s.Use(tt.version)
+			assert.Equal(t, tt.expectedResult, result)
+			assert.Equal(t, tt.expectedError, err)
+		})
+	}
+}
+
+func TestInstall(t *testing.T) {
+	tests := []struct {
+		name           string
+		version        string
+		expectedResult bool
+		expectedError  error
+	}{
+		{
+			name:           "Successful install",
+			version:        "0.8.20",
+			expectedResult: true,
+			expectedError:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, err := NewSelect()
+			assert.NoError(t, err, "NewSelect() should not return an error")
+			result, _, err := s.Install(tt.version)
+			assert.Equal(t, tt.expectedResult, result)
+			assert.Equal(t, tt.expectedError, err)
+		})
+	}
+}
+
+func TestVersions(t *testing.T) {
+	tests := []struct {
+		name          string
+		expectedError error
+	}{
+		{
+			name:          "Successful retrieval of versions",
+			expectedError: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, err := NewSelect()
+			assert.NoError(t, err, "NewSelect() should not return an error")
+			versions, err := s.Versions()
+			assert.GreaterOrEqual(t, len(versions), 1)
+			assert.Equal(t, tt.expectedError, err)
+		})
+	}
+}
+
+func TestUpgrade(t *testing.T) {
+	tests := []struct {
+		name           string
+		expectedResult bool
+		expectedError  error
+	}{
+		{
+			name:           "Successful upgrade",
+			expectedResult: true,
+			expectedError:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, err := NewSelect()
+			assert.NoError(t, err, "NewSelect() should not return an error")
+			result, err := s.Upgrade()
+			assert.Equal(t, tt.expectedResult, result)
+			assert.Equal(t, tt.expectedError, err)
+		})
+	}
+}
+
+func TestNewSelect(t *testing.T) {
+	t.Skip("Skipping test that requires solc-select to be installed")
+	tests := []struct {
+		name             string
+		expectedError    error
+		expectCurrentSet bool
+	}{
+		{
+			name:             "Successful initialization with solc-select installed",
+			expectedError:    nil,
+			expectCurrentSet: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, err := NewSelect()
+			assert.NoError(t, err, "NewSelect() should not return an error")
+
+			// If we expect the current version to be set, check it
+			if tt.expectCurrentSet {
+				assert.NotEmpty(t, s.Current())
+			}
+		})
+	}
+}

--- a/solc/types.go
+++ b/solc/types.go
@@ -1,0 +1,7 @@
+package solc
+
+// Version struct represents a solc versions installed on the current operating system.
+type Version struct {
+	Release string // The release version, for example: 0.5.0.
+	Current bool   // Whether this version is the current version in use.
+}


### PR DESCRIPTION
For now, what we have here is ability to use `solc-select` to switch the current used version of solc. 

Using and activating python virtual environment from now on should be essential. Otherwise, if you have python already in use on production, well good luck! 

Will see in the future to check and disable solc-select (trigger error) if python environment is not set!

Update: I've added the check for virtual environment. No need to know which environment as long as it's set. If it's not set, it will raise error and instructions on how to set the environment.

This above is thinking about people who will do crazy shit and run `make test` on production (like for example, me...).

Added environment variable `TEST_SOLGO_SOLC_SELECT_DISABLED`. If it's set to true it will not run these tests. This is a safety measure that can be taken into account.